### PR TITLE
Switch from jshint to eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,8 @@
+build/
+coverage/
+assets/
+node_modules/
+.grunt/
+
+Gruntfile.js
+3857.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,103 @@
+{
+    "extends": "angular",
+    "env": {
+        "browser": true,
+        "node": true
+    },
+    "globals": {
+        "ol": false,
+        "window": false,
+        "location": false,
+        "angular": false,
+        "solrHeatmapApp": false,
+        "proj4": false,
+
+        "afterEach": false,
+        "beforeEach": false,
+        "describe": false,
+        "document": false,
+        "expect": false,
+        "it": false,
+        "sinon": false
+    },
+    "rules": {
+        "angular/controller_name": 0,
+        "comma-dangle": 2,
+        "no-cond-assign": 2,
+        "no-console": 2,
+        "no-constant-condition": 2,
+        "no-control-regex": 2,
+        "no-debugger": 2,
+        "no-dupe-args": 2,
+        "no-dupe-keys": 2,
+        "no-duplicate-case": 2,
+        "no-empty-character-class": 2,
+        "no-empty": 2,
+        "no-ex-assign": 2,
+        "no-extra-boolean-cast": 2,
+        "no-extra-semi": 2,
+        "no-func-assign": 2,
+        "no-inner-declarations": 2,
+        "no-invalid-regexp": 2,
+        "no-irregular-whitespace": 2,
+        "no-negated-in-lhs": 2,
+        "no-obj-calls": 2,
+        "no-regex-spaces": 2,
+        "no-sparse-arrays": 2,
+        "no-unreachable": 2,
+        "use-isnan": 2,
+        "valid-typeof": 2,
+        "no-unexpected-multiline": 2,
+        "curly": 2,
+        "eqeqeq": 2,
+        "no-alert": 2,
+        "no-caller": 2,
+        "no-eval": 2,
+        "no-extend-native": 2,
+        "no-floating-decimal": 2,
+        "no-implied-eval": 2,
+        "no-loop-func": 2,
+        "no-multi-spaces": 1,
+        "no-multi-str": 2,
+        "no-new-func": 2,
+        "no-redeclare": 2,
+        "no-self-compare": 2,
+        "no-unused-expressions": 2,
+        "no-with": 2,
+        "radix": 2,
+        "wrap-iife": 2,
+        "strict": [
+            2,
+            "never"
+        ],
+        "no-catch-shadow": 2,
+        "no-delete-var": 2,
+        "no-shadow-restricted-names": 2,
+        "no-shadow": 2,
+        "no-undef": 2,
+        "no-unused-vars": 0,
+        "no-use-before-define": 1,
+        "brace-style": [
+            1,
+            "1tbs"
+        ],
+        "eol-last": 1,
+        "indent": 1,
+        "linebreak-style": [
+            2,
+            "unix"
+        ],
+        "no-mixed-spaces-and-tabs": 2,
+        "no-nested-ternary": 0,
+        "no-trailing-spaces": 2,
+        "semi": [
+            2,
+            "always"
+        ],
+        "max-len": [
+            1,
+            80,
+            4
+        ]
+    }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
 - '4'
 script:
-- npm run deploy
+- eslint -c .eslintrc ./ && npm run deploy
 branches:
   only:
   - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
 - '4'
 script:
-- eslint -c .eslintrc ./ && npm run deploy
+- npm run js-lint
+- npm run deploy
 branches:
   only:
   - master

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,6 @@ module.exports = function(grunt) {
 
     grunt.loadNpmTasks('grunt-contrib-clean');
     grunt.loadNpmTasks('grunt-gh-pages');
-    grunt.loadNpmTasks('grunt-contrib-jshint');
     grunt.loadNpmTasks('grunt-contrib-watch');
     grunt.loadNpmTasks('grunt-contrib-concat');
     grunt.loadNpmTasks('grunt-contrib-uglify');
@@ -30,24 +29,6 @@ module.exports = function(grunt) {
                 src: ['index.html', 'index-dev.html', 'app/**', 'build/**', 'assets/**', 'config/**', 'LICENSE', 'API/*.json']
             }
         },
-        jshint: {
-            files: ['Gruntfile.js', 'app/**/*.js'],
-            options: {
-                globals: {
-                    undef: true,
-                    unused: true,
-                    curly: true,
-                    eqeqeq: true,
-                    devel: false,
-                    globals: 'solrHeatmapApp',
-                    latedef: true
-                }
-            }
-        },
-        watch: {
-            files: ['<%= jshint.files %>'],
-            tasks: ['jshint']
-        },
         concat: {
             options: {
                 separator: '\n'
@@ -65,11 +46,11 @@ module.exports = function(grunt) {
               banner: '/*! Solr-Heatmap-Client created on <%= grunt.template.today("dd-mm-yyyy") %> */\n'
             },
             dist: {
-              files: {
-                'build/hm-client.min.js': ['<%= concat.dist.dest %>']
-              }
+                files: {
+                    'build/hm-client.min.js': ['<%= concat.dist.dest %>']
+                }
             }
-}
+        }
     });
 
     // get a formatted commit message to review changes from the commit log
@@ -100,14 +81,12 @@ module.exports = function(grunt) {
     });
 
     grunt.registerTask('publish', 'Publish from CLI', [
-        'jshint',
         'concat',
         'uglify',
         'gh-pages:publish'
     ]);
 
     grunt.registerTask('deploy', 'Publish from travis', [
-        'jshint',
         'concat',
         'uglify',
         'check-deploy'

--- a/app/controller/BackgroundLayer.js
+++ b/app/controller/BackgroundLayer.js
@@ -1,65 +1,69 @@
-/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.controller.*" }]*/
+/*eslint angular/di: [2,"array"]*/
 /**
  * BackgroundLayer Controller
  */
 angular
     .module('SolrHeatmapApp')
-    .controller('BackgroundLayerCtrl', ['Map', '$scope', function(MapService, $scope) {
+    .controller('BackgroundLayerController',
+        ['MapService', '$scope', function(MapService, $scope) {
 
-        /**
-         *
-         */
-        $scope.layers = {};
-        $scope.selectedLayer = {};
+            var vm = this;
 
-        /**
-         *
-         */
-        $scope.$on('mapReady', function(event, map) {
-            $scope.layers = map.getLayers().getArray();
-            $scope.selectedLayer = {
-                name: $scope.getBackgroundLayers()[0].get('name')
+            /**
+             *
+             */
+            vm.layers = {};
+            vm.selectedLayer = {};
+
+            /**
+             *
+             */
+            vm.$on('mapReady', function(event, map) {
+                vm.layers = map.getLayers().getArray();
+                vm.selectedLayer = {
+                    name: vm.getBackgroundLayers()[0].get('name')
+                };
+            });
+
+            /**
+             *
+             */
+            vm.isBackgroundLayer = function(layer) {
+                var isBackgroundLayer = false;
+                if (layer.get('backgroundLayer')) {
+                    isBackgroundLayer = true;
+                }
+                return isBackgroundLayer;
             };
-        });
 
-        /**
-         *
-         */
-        $scope.isBackgroundLayer = function(layer) {
-            var isBackgroundLayer = false;
-            if (layer.get('backgroundLayer')) {
-                isBackgroundLayer = true;
-            }
-            return isBackgroundLayer;
-        };
+            /**
+             *
+             */
+            vm.setBackgroundLayer = function(layer) {
+                angular.forEach(vm.getBackgroundLayers(), function(bgLayer) {
+                    if (bgLayer === layer) {
+                        layer.setVisible(true);
+                        vm.selectedLayer = {name: layer.get('name')};
+                    } else {
+                        bgLayer.setVisible(false);
+                    }
+                });
+            };
 
-        /**
-         *
-         */
-        $scope.setBackgroundLayer = function(layer) {
-            angular.forEach($scope.getBackgroundLayers(), function(bgLayer) {
-                if (bgLayer === layer) {
-                    layer.setVisible(true);
-                    $scope.selectedLayer = {name: layer.get('name')};
-                } else {
-                    bgLayer.setVisible(false);
-                }
-            });
-        };
+            /**
+             *
+             */
+            vm.getBackgroundLayers = function() {
+                var layers = MapService.getMap().getLayers().getArray();
 
-        /**
-         *
-         */
-        $scope.getBackgroundLayers = function() {
-            var layers = MapService.getMap().getLayers().getArray();
+                return layers.filter(function(l) {
+                    if (l.get('backgroundLayer')) {
+                        return true;
+                    } else {
+                        return false;
+                    }
+                });
+            };
 
-            return layers.filter(function(l) {
-                if (l.get('backgroundLayer')) {
-                    return true;
-                } else {
-                    return false;
-                }
-            });
-        };
-
-    }]);
+        }]
+);

--- a/app/controller/BackgroundLayer.js
+++ b/app/controller/BackgroundLayer.js
@@ -1,3 +1,4 @@
+/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.controller.*" }]*/
 /**
  * BackgroundLayer Controller
  */

--- a/app/controller/DatePickerCtrl.js
+++ b/app/controller/DatePickerCtrl.js
@@ -1,88 +1,94 @@
-/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.controller.*" }]*/
+/*eslint angular/di: [2,"array"]*/
+/*eslint max-len: [2,100]*/
 /**
  * DatePickerCtrl Controller
  */
 angular.module('SolrHeatmapApp')
-    .controller('DatePickerCtrl', ['HeatMapSourceGenerator', '$scope', function(HeatMapSourceGeneratorService, $scope) {
+    .controller('DatePickerController',
+        ['HeatMapSourceGenerator', '$scope', function(HeatMapSourceGeneratorService, $scope) {
 
-        $scope.initialDateOptions = {
-            minDate: new Date('2000-01-01'),
-            maxDate: new Date('2016-12-31')
-        };
+            var vm = this;
 
-        $scope.dateOptions = {
-            minDate: HeatMapSourceGeneratorService.getSearchObj().minDate,
-            maxDate: HeatMapSourceGeneratorService.getSearchObj().maxDate,
-            startingDay: 1, // Monday
-            showWeeks: false
-        };
+            vm.initialDateOptions = {
+                minDate: new Date('2000-01-01'),
+                maxDate: new Date('2016-12-31')
+            };
 
-        /**
-         * Will be called on click on start datepicker.
-         * `minDate` will be reset to the initial value (e.g. 2000-01-01),
-         * `maxDate` will be adjusted with the `$scope.dte` value to restrict
-         *  it not to be below the `minDate`.
-         */
-        $scope.openStartDate = function() {
-            $scope.startDate.opened = true;
-            $scope.dateOptions.minDate = $scope.initialDateOptions.minDate;
-            $scope.dateOptions.maxDate = $scope.dte;
-        };
+            vm.dateOptions = {
+                minDate: HeatMapSourceGeneratorService.getSearchObj().minDate,
+                maxDate: HeatMapSourceGeneratorService.getSearchObj().maxDate,
+                startingDay: 1, // Monday
+                showWeeks: false
+            };
 
-        /**
-         * Will be called on click on end datepicker.
-         * `maxDate` will be reset to the initial value (e.g. 2016-12-31),
-         * `minDate` will be adjusted with the `$scope.dts` value to restrict
-         *  it not to be bigger than the `maxDate`.
-         */
-        $scope.openEndDate = function() {
-            $scope.endDate.opened = true;
-            $scope.dateOptions.maxDate = $scope.initialDateOptions.maxDate;
-            $scope.dateOptions.minDate = $scope.dts;
-        };
+            /**
+             * Will be called on click on start datepicker.
+             * `minDate` will be reset to the initial value (e.g. 2000-01-01),
+             * `maxDate` will be adjusted with the `$scope.dte` value to
+             *  restrict it not to be below the `minDate`.
+             */
+            vm.openStartDate = function() {
+                vm.startDate.opened = true;
+                vm.dateOptions.minDate = vm.initialDateOptions.minDate;
+                vm.dateOptions.maxDate = vm.dte;
+            };
 
-        $scope.startDate = {
-            opened: false
-        };
+            /**
+             * Will be called on click on end datepicker.
+             * `maxDate` will be reset to the initial value (e.g. 2016-12-31),
+             * `minDate` will be adjusted with the `$scope.dts` value to
+             *  restrict it not to be bigger than the `maxDate`.
+             */
+            vm.openEndDate = function() {
+                vm.endDate.opened = true;
+                vm.dateOptions.maxDate = vm.initialDateOptions.maxDate;
+                vm.dateOptions.minDate = vm.dts;
+            };
 
-        $scope.endDate = {
-            opened: false
-        };
+            vm.startDate = {
+                opened: false
+            };
 
-        /**
-         * Set initial values for min and max dates in both of datepicker.
-         */
-        $scope.setInitialDates = function(){
-            $scope.dts = $scope.dateOptions.minDate;
-            $scope.dte = $scope.dateOptions.maxDate;
-        };
+            vm.endDate = {
+                opened: false
+            };
 
-        $scope.setInitialDates();
+            /**
+             * Set initial values for min and max dates in both of datepicker.
+             */
+            vm.setInitialDates = function(){
+                vm.dts = vm.dateOptions.minDate;
+                vm.dte = vm.dateOptions.maxDate;
+            };
 
-        /**
-         * Will be fired after the start date was chosen.
-         */
-        $scope.onChangeStartDate = function(){
-            $scope.setDateRange($scope.dts, $scope.dte);
-            HeatMapSourceGeneratorService.performSearch();
-        };
+            vm.setInitialDates();
 
-        /**
-         * Will be fired after the end date was chosen.
-         */
-        $scope.onChangeEndDate = function(){
-            $scope.setDateRange($scope.dts, $scope.dte);
-            HeatMapSourceGeneratorService.performSearch();
-        };
+            /**
+             * Will be fired after the start date was chosen.
+             */
+            vm.onChangeStartDate = function(){
+                vm.setDateRange(vm.dts, vm.dte);
+                HeatMapSourceGeneratorService.performSearch();
+            };
 
-        /**
-         * Help method that updates `searchObj` of the heatmap with
-         * the current min and max dates.
-         * @param {Date} minDate date value of the start datepicker
-         * @param {Date} maxDate date value of the end datepicker
-         */
-        $scope.setDateRange = function(minDate, maxDate){
-            HeatMapSourceGeneratorService.setMinDate(minDate);
-            HeatMapSourceGeneratorService.setMaxDate(maxDate);
-        };
-    }]);
+            /**
+             * Will be fired after the end date was chosen.
+             */
+            vm.onChangeEndDate = function(){
+                vm.setDateRange(vm.dts, vm.dte);
+                HeatMapSourceGeneratorService.performSearch();
+            };
+
+            /**
+             * Help method that updates `searchObj` of the heatmap with
+             * the current min and max dates.
+             * @param {Date} minDate date value of the start datepicker
+             * @param {Date} maxDate date value of the end datepicker
+             */
+            vm.setDateRange = function(minDate, maxDate){
+                HeatMapSourceGeneratorService.setMinDate(minDate);
+                HeatMapSourceGeneratorService.setMaxDate(maxDate);
+            };
+        }]
+
+);

--- a/app/controller/DatePickerCtrl.js
+++ b/app/controller/DatePickerCtrl.js
@@ -1,3 +1,4 @@
+/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.controller.*" }]*/
 /**
  * DatePickerCtrl Controller
  */
@@ -81,7 +82,7 @@ angular.module('SolrHeatmapApp')
          * @param {Date} maxDate date value of the end datepicker
          */
         $scope.setDateRange = function(minDate, maxDate){
-          HeatMapSourceGeneratorService.setMinDate(minDate);
-          HeatMapSourceGeneratorService.setMaxDate(maxDate);
+            HeatMapSourceGeneratorService.setMinDate(minDate);
+            HeatMapSourceGeneratorService.setMaxDate(maxDate);
         };
     }]);

--- a/app/controller/Export.js
+++ b/app/controller/Export.js
@@ -1,12 +1,16 @@
-/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.controller.*" }]*/
+/*eslint angular/controller-as: 0*/
+/*eslint angular/di: [2,"array"]*/
 /**
  * Export Controller
  */
 angular
     .module('SolrHeatmapApp')
-    .controller('ExportCtrl', ['HeatMapSourceGenerator', '$scope', function(HeatMapSourceGeneratorService, $scope) {
+    .controller('ExportController', ['HeatMapSourceGenerator', '$scope',
+        function(HeatMapSourceGeneratorService, $scope) {
 
-        $scope.startExport = function() {
-            HeatMapSourceGeneratorService.startCsvExport();
-        };
-    }]);
+            $scope.startExport = function() {
+                HeatMapSourceGeneratorService.startCsvExport();
+            };
+        }]
+
+);

--- a/app/controller/Export.js
+++ b/app/controller/Export.js
@@ -1,3 +1,4 @@
+/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.controller.*" }]*/
 /**
  * Export Controller
  */
@@ -6,6 +7,6 @@ angular
     .controller('ExportCtrl', ['HeatMapSourceGenerator', '$scope', function(HeatMapSourceGeneratorService, $scope) {
 
         $scope.startExport = function() {
-          HeatMapSourceGeneratorService.startCsvExport();
+            HeatMapSourceGeneratorService.startCsvExport();
         };
     }]);

--- a/app/controller/Main.js
+++ b/app/controller/Main.js
@@ -1,3 +1,4 @@
+/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.controller.*" }]*/
 /**
  * Main Controller
  */
@@ -24,24 +25,28 @@ angular
                     $rootScope.$broadcast('mapReady', MapService.getMap());
 
                     MapService.getMap().on('moveend', function(evt){
-                      HeatMapSourceGeneratorService.performSearch();
+                        HeatMapSourceGeneratorService.performSearch();
                     });
 
-                    MapService.getMap().getView().on('change:resolution', function(evt){
-                      var existingHeatMapLayers = MapService.getLayersBy('name', 'HeatMapLayer');
-                      if (existingHeatMapLayers && existingHeatMapLayers.length > 0){
-                        var radius = 500 * evt.target.getResolution();
-                        var hmLayer = existingHeatMapLayers[0];
-                        if (radius > 15) {
-                          radius = 15;
+                    MapService.getMap().getView()
+                    .on('change:resolution', function(evt){
+                        var existingHeatMapLayers = MapService.
+                                        getLayersBy('name', 'HeatMapLayer');
+                        if (existingHeatMapLayers &&
+                                existingHeatMapLayers.length > 0){
+                            var radius = 500 * evt.target.getResolution();
+                            var hmLayer = existingHeatMapLayers[0];
+                            if (radius > 15) {
+                                radius = 15;
+                            }
+                            hmLayer.setRadius(radius);
+                            hmLayer.setBlur(radius*2);
                         }
-                        hmLayer.setRadius(radius);
-                        hmLayer.setBlur(radius*2);
-                      }
                     });
 
                   // Prepared featureInfo (display number of elements)
-                  //solrHeatmapApp.map.on('singleclick', MapService.displayFeatureInfo);
+                  //solrHeatmapApp.map.on('singleclick',
+                  //                          MapService.displayFeatureInfo);
 
                 } else {
                     throw 'Could not find the mapConfig';

--- a/app/controller/Main.js
+++ b/app/controller/Main.js
@@ -1,58 +1,65 @@
-/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.controller.*" }]*/
+/*eslint angular/no-services: [2,{"directive":["$http","$q"],"controller":["$resource"]}]*/
+/*eslint angular/di: [2,"array"]*/
+/*eslint max-len: [2,110]*/
 /**
  * Main Controller
  */
 angular
     .module('SolrHeatmapApp')
-    .controller('mainCtrl', ['Map', 'HeatMapSourceGenerator' , '$http', '$scope', '$rootScope', function(MapService, HeatMapSourceGeneratorService, $http, $scope, $rootScope) {
-        solrHeatmapApp = this;
+    .controller('MainController', ['Map', 'HeatMapSourceGenerator' , '$http', '$scope', '$rootScope',
+        function(MapService, HeatMapSourceGeneratorService, $http, $scope, $rootScope) {
 
-       //  get the app config
-        $http.get('./config/appConfig.json').
-            success(function(data, status, headers, config) {
-                if (data && data.mapConfig) {
-                    var mapConf = data.mapConfig,
-                        appConf = data.appConfig,
-                        bopwsConfig = data.bopwsConfig;
-                    // create the map with the given config
-                    MapService.init({
-                        mapConfig: mapConf
-                    });
-                    solrHeatmapApp.appConfig = appConf;
-                    solrHeatmapApp.initMapConf = mapConf;
-                    solrHeatmapApp.bopwsConfig = bopwsConfig;
-                    // fire event mapReady
-                    $rootScope.$broadcast('mapReady', MapService.getMap());
+            var vm = this;
 
-                    MapService.getMap().on('moveend', function(evt){
-                        HeatMapSourceGeneratorService.performSearch();
-                    });
+            solrHeatmapApp = vm;
 
-                    MapService.getMap().getView()
-                    .on('change:resolution', function(evt){
-                        var existingHeatMapLayers = MapService.
-                                        getLayersBy('name', 'HeatMapLayer');
-                        if (existingHeatMapLayers &&
-                                existingHeatMapLayers.length > 0){
-                            var radius = 500 * evt.target.getResolution();
-                            var hmLayer = existingHeatMapLayers[0];
-                            if (radius > 15) {
-                                radius = 15;
+            //  get the app config
+            $http.get('./config/appConfig.json').
+                success(function(data, status, headers, config) {
+                    if (data && data.mapConfig) {
+                        var mapConf = data.mapConfig,
+                            appConf = data.appConfig,
+                            bopwsConfig = data.bopwsConfig;
+                        // create the map with the given config
+                        MapService.init({
+                            mapConfig: mapConf
+                        });
+                        solrHeatmapApp.appConfig = appConf;
+                        solrHeatmapApp.initMapConf = mapConf;
+                        solrHeatmapApp.bopwsConfig = bopwsConfig;
+                        // fire event mapReady
+                        $rootScope.$broadcast('mapReady', MapService.getMap());
+
+                        MapService.getMap().on('moveend', function(evt){
+                            HeatMapSourceGeneratorService.performSearch();
+                        });
+
+                        MapService.getMap().getView()
+                        .on('change:resolution', function(evt){
+                            var existingHeatMapLayers = MapService.
+                                            getLayersBy('name', 'HeatMapLayer');
+                            if (existingHeatMapLayers &&
+                                    existingHeatMapLayers.length > 0){
+                                var radius = 500 * evt.target.getResolution();
+                                var hmLayer = existingHeatMapLayers[0];
+                                if (radius > 15) {
+                                    radius = 15;
+                                }
+                                hmLayer.setRadius(radius);
+                                hmLayer.setBlur(radius*2);
                             }
-                            hmLayer.setRadius(radius);
-                            hmLayer.setBlur(radius*2);
-                        }
-                    });
+                        });
 
-                  // Prepared featureInfo (display number of elements)
-                  //solrHeatmapApp.map.on('singleclick',
-                  //                          MapService.displayFeatureInfo);
+                      // Prepared featureInfo (display number of elements)
+                      //solrHeatmapApp.map.on('singleclick',
+                      //                          MapService.displayFeatureInfo);
 
-                } else {
-                    throw 'Could not find the mapConfig';
-                }
-            }).
-            error(function(data, status, headers, config) {
-                throw 'Error while loading the config.json';
-            });
-    }]);
+                    } else {
+                        throw 'Could not find the mapConfig';
+                    }
+                }).
+                error(function(data, status, headers, config) {
+                    throw 'Error while loading the config.json';
+                });
+        }]
+);

--- a/app/controller/ResultCounter.js
+++ b/app/controller/ResultCounter.js
@@ -6,9 +6,9 @@ angular
     .controller('ResultCounterCtrl', ['$scope', function($scope) {
 
         $scope.$on('setCounter', function(e, data){
-          if (data < 1) {
-              data = "No results found";
-          }
+            if (data < 1) {
+                data = "No results found";
+            }
             $scope.counter = data;
         });
     }]);

--- a/app/controller/ResultCounter.js
+++ b/app/controller/ResultCounter.js
@@ -1,9 +1,11 @@
+/*eslint angular/di: [2,"array"]*/
+/*eslint angular/controller-as: 0*/
 /**
  * ResultCounter Controller
  */
 angular
     .module('SolrHeatmapApp')
-    .controller('ResultCounterCtrl', ['$scope', function($scope) {
+    .controller('ResultCounterController', ['$scope', function($scope) {
 
         $scope.$on('setCounter', function(e, data){
             if (data < 1) {

--- a/app/controller/Search.js
+++ b/app/controller/Search.js
@@ -1,48 +1,54 @@
-/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.controller.*" }]*/
+/*eslint angular/controller-as: 0*/
+/*eslint angular/di: [2,"array"]*/
+/*eslint max-len: [2,100]*/
 /**
  * Search Controller
  */
 angular.module('SolrHeatmapApp')
-    .controller('SearchCtrl', ['Map', 'HeatMapSourceGenerator', '$scope', function(MapService, HeatMapSourceGeneratorService, $scope) {
+    .controller('SearchController', ['Map', 'HeatMapSourceGenerator', '$scope', '$window',
+        function(MapService, HeatMapSourceGeneratorService, $scope, $window) {
 
-        /**
-         *
-         */
-        $scope.searchInput = '';
-        /**
-         *
-         */
-        $scope.onKeyPress = function($event) {
-            // only fire the search if Enter-key (13) is pressed
-            if (getKeyboardCodeFromEvent($event) === 13) {
-                $scope.doSearch();
-            }
-        };
-
-        /**
-         *
-         */
-        $scope.doSearch = function() {
-            // if no input is given
-            // if ($scope.searchInput.length === 0) {
-            //    return false;
-            // }
-
-            HeatMapSourceGeneratorService.setSearchText($scope.searchInput);
-            HeatMapSourceGeneratorService.performSearch();
-        };
-
-        $scope.resetSearchInput = function() {
+            /**
+             *
+             */
             $scope.searchInput = '';
-            HeatMapSourceGeneratorService.setSearchText('');
-            HeatMapSourceGeneratorService.performSearch();
-        };
 
-        /**
-         *
-         */
-        function getKeyboardCodeFromEvent(keyEvt) {
-            return window.event ? keyEvt.keyCode : keyEvt.which;
-        }
+            /**
+             *
+             */
+            function getKeyboardCodeFromEvent(keyEvt) {
+                return $window.event ? keyEvt.keyCode : keyEvt.which;
+            }
 
-    }]);
+            /**
+             *
+             */
+            $scope.onKeyPress = function($event) {
+                // only fire the search if Enter-key (13) is pressed
+                if (getKeyboardCodeFromEvent($event) === 13) {
+                    $scope.doSearch();
+                }
+            };
+
+            /**
+             *
+             */
+            $scope.doSearch = function() {
+                // if no input is given
+                // if ($scope.searchInput.length === 0) {
+                //    return false;
+                // }
+
+                HeatMapSourceGeneratorService.setSearchText($scope.searchInput);
+                HeatMapSourceGeneratorService.performSearch();
+            };
+
+            $scope.resetSearchInput = function() {
+                $scope.searchInput = '';
+                HeatMapSourceGeneratorService.setSearchText('');
+                HeatMapSourceGeneratorService.performSearch();
+            };
+
+        }]
+
+);

--- a/app/controller/Search.js
+++ b/app/controller/Search.js
@@ -5,8 +5,8 @@
  * Search Controller
  */
 angular.module('SolrHeatmapApp')
-    .controller('SearchController', ['Map', 'HeatMapSourceGenerator', '$scope', '$window',
-        function(MapService, HeatMapSourceGeneratorService, $scope, $window) {
+    .controller('SearchController', ['HeatMapSourceGenerator', '$scope', '$window',
+        function(HeatMapSourceGeneratorService, $scope, $window) {
 
             /**
              *

--- a/app/controller/Search.js
+++ b/app/controller/Search.js
@@ -1,9 +1,9 @@
+/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.controller.*" }]*/
 /**
  * Search Controller
  */
-angular
-    .module('SolrHeatmapApp')
-    .controller('SearchCtrl', ['Map', 'HeatMapSourceGenerator', '$scope', '$http', function(MapService, HeatMapSourceGeneratorService, $scope, $http) {
+angular.module('SolrHeatmapApp')
+    .controller('SearchCtrl', ['Map', 'HeatMapSourceGenerator', '$scope', function(MapService, HeatMapSourceGeneratorService, $scope) {
 
         /**
          *
@@ -28,14 +28,14 @@ angular
             //    return false;
             // }
 
-          HeatMapSourceGeneratorService.setSearchText($scope.searchInput);
-          HeatMapSourceGeneratorService.performSearch();
+            HeatMapSourceGeneratorService.setSearchText($scope.searchInput);
+            HeatMapSourceGeneratorService.performSearch();
         };
 
         $scope.resetSearchInput = function() {
-          $scope.searchInput = '';
-          HeatMapSourceGeneratorService.setSearchText('');
-          HeatMapSourceGeneratorService.performSearch();
+            $scope.searchInput = '';
+            HeatMapSourceGeneratorService.setSearchText('');
+            HeatMapSourceGeneratorService.performSearch();
         };
 
         /**

--- a/app/service/HeatMapSourceGenerator.js
+++ b/app/service/HeatMapSourceGenerator.js
@@ -1,3 +1,4 @@
+/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.factory.*" }]*/
 /**
  * HeatMapSourceGenerator Service
  */
@@ -62,12 +63,12 @@ angular
             var map = MapService.getMap(),
                 viewProj = map.getView().getProjection().getCode(),
                 extent = map.getView().calculateExtent(map.getSize()),
-                extentWgs84 = ol.proj.transformExtent(extent, viewProj, 'EPSG:4326'),
+                extentWgs84 = ol.proj.
+                                transformExtent(extent, viewProj, 'EPSG:4326'),
                 geoFilter = {};
 
             if (extent && extentWgs84){
-
-              var normalizedExtent = normalize(extentWgs84);
+                var normalizedExtent = normalize(extentWgs84);
 
                 var minX = normalizedExtent[1],
                     maxX = normalizedExtent[3],
@@ -89,36 +90,36 @@ angular
          * Performs search with the given full configuration / search object.
          */
         function performSearch(){
-          var config = {},
-              params = this.getTweetsSearchQueryParameters(this.getGeospatialFilter());
+            var config = {},
+                params = this.getTweetsSearchQueryParameters(
+                                                this.getGeospatialFilter());
 
          // add additional parameter for the soft maximum of the heatmap grid
-        params["a.hm.limit"] = solrHeatmapApp.bopwsConfig.heatmapFacetLimit;
+            params["a.hm.limit"] = solrHeatmapApp.bopwsConfig.heatmapFacetLimit;
 
-          if (params) {
+            if (params) {
 
-              config = {
-                  url: solrHeatmapApp.appConfig.tweetsSearchBaseUrl,
-                  method: 'GET',
-                  params: params
-              };
+                config = {
+                    url: solrHeatmapApp.appConfig.tweetsSearchBaseUrl,
+                    method: 'GET',
+                    params: params
+                };
 
-            //load the data
-            $http(config).
-            success(function(data, status, headers, config) {
-                // check if we have a heatmap facet and update the map with it
-                if (data && data["a.hm"]) {
-                    MapService.createOrUpdateHeatMapLayer(data["a.hm"]);
-                    // get the count of matches
-                    $rootScope.$broadcast('setCounter', data["a.matchDocs"]);
-                }
-            }).
-            error(function(data, status, headers, config) {
-                // hide the loading mask
-                //angular.element(document.querySelector('.waiting-modal')).modal('hide');
-                $window.alert("An error occured while reading heatmap data");
-            });
-          }
+              //load the data
+                $http(config).
+                success(function(data, status, headers, cfg) {
+                    // check if we have a heatmap facet and update the map
+                    if (data && data["a.hm"]) {
+                        MapService.createOrUpdateHeatMapLayer(data["a.hm"]);
+                        // get the count of matches
+                        $rootScope.$broadcast('setCounter',data["a.matchDocs"]);
+                    }
+                }).
+                error(function(data, status, headers, cfg) {
+                    // hide the loading mask
+                    $window.alert("An error occured while reading heatmap");
+                });
+            }
         }
 
         /**
@@ -127,9 +128,11 @@ angular
          */
         function startCsvExport(){
             var config = {},
-                params = this.getTweetsSearchQueryParameters(this.getGeospatialFilter());
-                // add additional parameter for the number of documents to return
-                params["d.docs.limit"] = solrHeatmapApp.bopwsConfig.csvDocsLimit;
+                params = this.getTweetsSearchQueryParameters(
+                                        this.getGeospatialFilter());
+                // add additional parameter for number of documents to return
+            params["d.docs.limit"] =
+                            solrHeatmapApp.bopwsConfig.csvDocsLimit;
 
             if (params) {
                 config = {
@@ -140,18 +143,20 @@ angular
 
                 //start the export
                 $http(config).
-                success(function(data, status, headers, config) {
+                success(function(data, status, headers, cfg) {
                     var anchor = angular.element('<a/>');
                     anchor.css({display: 'none'}); // Make sure it's not visible
-                    angular.element(document.body).append(anchor); // Attach to document
+                    angular.element(document.body).append(anchor);
+                     // Attach to document
                     anchor.attr({
-                        href: 'data:attachment/csv;charset=utf-8,' + encodeURI(data),
+                        href: 'data:attachment/csv;charset=utf-8,' +
+                                                            encodeURI(data),
                         target: '_blank',
-                       download: 'bop_export.csv'
+                        download: 'bop_export.csv'
                     })[0].click();
                     anchor.remove(); // Clean it up afterwards
                 }).
-                error(function(data, status, headers, config) {
+                error(function(data, status, headers, cfg) {
                     $window.alert("An error occured while exporting csv data");
                 });
             }
@@ -174,39 +179,42 @@ angular
 
             var params = {
                 "q.text": keyword,
-                "q.time": '[' + this.getFormattedDateString(reqParamsUi.minDate) + ' TO ' + this.getFormattedDateString(reqParamsUi.maxDate) + ']',
-                "q.geo": '[' + bounds.minX + ',' + bounds.minY + ' TO ' + bounds.maxX + ',' + bounds.maxY + ']'
+                "q.time": '[' + this.getFormattedDateString(reqParamsUi.minDate)
+                    + ' TO ' + this.getFormattedDateString(reqParamsUi.maxDate)
+                    + ']',
+                "q.geo": '[' + bounds.minX + ',' + bounds.minY + ' TO '
+                            + bounds.maxX + ',' + bounds.maxY + ']'
             };
 
-           return params;
+            return params;
         }
 
         /**
-         * Determines whether passed longitude is outside of the range `-180` and
-         * `+180`.
+         * Determines whether passed longitude is outside of the range `-180`
+         * and `+180`.
          *
          * @param {number} lon The longitude to check.
-         * @return {boolean} Whether the longitude is outside of the range `-180` and
-         *   `+180`.
+         * @return {boolean} Whether the longitude is outside of the range
+         *  -180` and `+180`.
          */
         function outsideLonRange(lon) {
             return lon < -180 || lon > 180;
         }
 
         /**
-         * Determines whether passed latitude is outside of the range `-90` and `+90`.
-         *
+         * Determines whether passed latitude is outside of the range `-90` and
+         * `+90`.
          * @param {number} lat The longitude to check.
-         * @return {boolean} Whether the latitude is outside of the range `-90` and
-         *   `+90`.
+         * @return {boolean} Whether the latitude is outside of the range `-90`
+         *  and `+90`.
          */
         function outsideLatRange(lat) {
             return lat < -90 || lat > 90;
         }
 
         /**
-         * Clamps given longitude to be inside the allowed range from `-180` to `+180`.
-         *
+         * Clamps given longitude to be inside the allowed range from `-180` to
+         * `+180`.
          * @param {number} lon The longitude to fit / clamp.
          * @return {number} The fitted / clamped longitude.
          */
@@ -215,8 +223,8 @@ angular
         }
 
         /**
-         * Clamps given latitude to be inside the allowed range from `-90` to `+90`.
-         *
+         * Clamps given latitude to be inside the allowed range from `-90` to
+         * `+90`.
          * @param {number} lat The latitude to fit / clamp.
          * @return {number} The fitted / clamped latitude.
          */
@@ -225,7 +233,8 @@ angular
         }
 
         /**
-         * Clamps given number `num` to be inside the allowed range from `min` to `max`.
+         * Clamps given number `num` to be inside the allowed range from `min`
+         * to `max`.
          * Will also work as expected if `max` and `min` are accidently swapped.
          *
          * @param {number} num The number to clamp.
@@ -243,9 +252,9 @@ angular
         }
 
         /**
-         * Normalizes an `EPSG:4326` extent which may stem from multiple worlds so that
-         * the returned extent always is within the bounds of the one true `EPSG:4326`
-         * world extent `[-180, -90, 180, 90]`.
+         * Normalizes an `EPSG:4326` extent which may stem from multiple worlds
+         * so that the returned extent always is within the bounds of the one
+         * true `EPSG:4326` world extent `[-180, -90, 180, 90]`.
          *
          * Examples:
          *
@@ -273,8 +282,8 @@ angular
          *     // multiple worlds, returns one-true world:
          *     normalize([-360, -180, 180, 90]) // =>  [-180, -90, 180, 90]);
          *
-         * @param {Array<number>} extent Extent to normalize: [minx, miny, maxx, maxy].
-         * @return {Array<number>} extent Normalized extent: [minx, miny, maxx, maxy].
+         * @param {Array<number>} Extent to normalize: [minx, miny, maxx, maxy].
+         * @return {Array<number>} Normalized extent: [minx, miny, maxx, maxy].
          */
         function normalize(extent) {
             var minX = extent[0];
@@ -305,10 +314,13 @@ angular
 
         /**
          * Returns the formatted date object that can be parsed by API.
-         * @param {Date} date full date object (e.g. 'Sat Jan 01 2000 01:00:00 GMT+0100 (CET))
+         * @param {Date} date full date object
+                        (e.g. 'Sat Jan 01 2000 01:00:00 GMT+0100 (CET))
          * @return {String} formatted date as string (e.g. '2000-01-01')
          */
-         function getFormattedDateString(date){
-             return date.getFullYear() + "-" + ("0" + (date.getMonth() + 1)).slice(-2) + "-" + ("0" + date.getDate()).slice(-2);
-         }
+        function getFormattedDateString(date){
+            return date.getFullYear() + "-" + ("0" +
+                (date.getMonth() + 1)).slice(-2) + "-" + ("0" + date.getDate()).
+                slice(-2);
+        }
     }]);

--- a/app/service/HeatMapSourceGenerator.js
+++ b/app/service/HeatMapSourceGenerator.js
@@ -1,326 +1,331 @@
-/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.factory.*" }]*/
+/*eslint angular/di: [2,"array"]*/
+/*eslint angular/document-service: 2*/
+/*eslint max-len: [2,110]*/
 /**
  * HeatMapSourceGenerator Service
  */
 angular
     .module('SolrHeatmapApp')
-    .factory('HeatMapSourceGenerator', ['Map', '$rootScope', '$filter', '$window', '$http', function(MapService, $rootScope, $filter, $window, $http) {
+    .factory('HeatMapSourceGenerator', ['Map', '$rootScope', '$filter', '$window', '$document', '$http',
+        function(MapService, $rootScope, $filter, $window, $document , $http) {
 
-        var searchObj = {
-            minDate: new Date('2000-01-01'),
-            maxDate: new Date('2016-12-31'),
-            searchText : ''
-        };
-
-        var methods = {
-            getGeospatialFilter: getGeospatialFilter,
-            getTweetsSearchQueryParameters: getTweetsSearchQueryParameters,
-            performSearch: performSearch,
-            startCsvExport: startCsvExport,
-            setSearchText: setSearchText,
-            setMinDate: setMinDate,
-            setMaxDate: setMaxDate,
-            getFormattedDateString: getFormattedDateString,
-            getSearchObj: getSearchObj
-        };
-
-        return methods;
-
-        /**
-         * Set keyword text
-         */
-        function setSearchText(val) {
-            searchObj.searchText = val;
-        }
-
-        /**
-         * Set start search date
-         */
-        function setMinDate(val) {
-            searchObj.minDate = val;
-        }
-
-        /**
-         * Set end search date
-         */
-        function setMaxDate (val) {
-            searchObj.maxDate = val;
-        }
-
-        /**
-         * Returns the complete search object
-         */
-        function getSearchObj(){
-            return searchObj;
-        }
-
-        /**
-         * Builds geospatial filter depending on the current map extent.
-         * This filter will be used later for `q.geo` parameter of the API
-         * search or export request.
-         */
-        function getGeospatialFilter(){
-            var map = MapService.getMap(),
-                viewProj = map.getView().getProjection().getCode(),
-                extent = map.getView().calculateExtent(map.getSize()),
-                extentWgs84 = ol.proj.
-                                transformExtent(extent, viewProj, 'EPSG:4326'),
-                geoFilter = {};
-
-            if (extent && extentWgs84){
-                var normalizedExtent = normalize(extentWgs84);
-
-                var minX = normalizedExtent[1],
-                    maxX = normalizedExtent[3],
-                    minY = normalizedExtent[0],
-                    maxY = normalizedExtent[2];
-
-                geoFilter = {
-                    minX: minX,
-                    maxX: maxX,
-                    minY: minY,
-                    maxY: maxY
-                };
-            }
-
-            return geoFilter;
-        }
-
-        /**
-         * Performs search with the given full configuration / search object.
-         */
-        function performSearch(){
-            var config = {},
-                params = this.getTweetsSearchQueryParameters(
-                                                this.getGeospatialFilter());
-
-         // add additional parameter for the soft maximum of the heatmap grid
-            params["a.hm.limit"] = solrHeatmapApp.bopwsConfig.heatmapFacetLimit;
-
-            if (params) {
-
-                config = {
-                    url: solrHeatmapApp.appConfig.tweetsSearchBaseUrl,
-                    method: 'GET',
-                    params: params
-                };
-
-              //load the data
-                $http(config).
-                success(function(data, status, headers, cfg) {
-                    // check if we have a heatmap facet and update the map
-                    if (data && data["a.hm"]) {
-                        MapService.createOrUpdateHeatMapLayer(data["a.hm"]);
-                        // get the count of matches
-                        $rootScope.$broadcast('setCounter',data["a.matchDocs"]);
-                    }
-                }).
-                error(function(data, status, headers, cfg) {
-                    // hide the loading mask
-                    $window.alert("An error occured while reading heatmap");
-                });
-            }
-        }
-
-        /**
-         * Help method to build the whole params object, that will be used in
-         * the API requests.
-         */
-        function startCsvExport(){
-            var config = {},
-                params = this.getTweetsSearchQueryParameters(
-                                        this.getGeospatialFilter());
-                // add additional parameter for number of documents to return
-            params["d.docs.limit"] =
-                            solrHeatmapApp.bopwsConfig.csvDocsLimit;
-
-            if (params) {
-                config = {
-                    url: solrHeatmapApp.appConfig.tweetsExportBaseUrl,
-                    method: 'GET',
-                    params: params
-                };
-
-                //start the export
-                $http(config).
-                success(function(data, status, headers, cfg) {
-                    var anchor = angular.element('<a/>');
-                    anchor.css({display: 'none'}); // Make sure it's not visible
-                    angular.element(document.body).append(anchor);
-                     // Attach to document
-                    anchor.attr({
-                        href: 'data:attachment/csv;charset=utf-8,' +
-                                                            encodeURI(data),
-                        target: '_blank',
-                        download: 'bop_export.csv'
-                    })[0].click();
-                    anchor.remove(); // Clean it up afterwards
-                }).
-                error(function(data, status, headers, cfg) {
-                    $window.alert("An error occured while exporting csv data");
-                });
-            }
-        }
-
-        /**
-         *
-         */
-        function getTweetsSearchQueryParameters(bounds) {
-
-            // get keyword and time range
-            var reqParamsUi = this.getSearchObj(),
-                keyword;
-
-            if (reqParamsUi.searchText.length === 0){
-                keyword = '*';
-            } else {
-                keyword = reqParamsUi.searchText;
-            }
-
-            var params = {
-                "q.text": keyword,
-                "q.time": '[' + this.getFormattedDateString(reqParamsUi.minDate)
-                    + ' TO ' + this.getFormattedDateString(reqParamsUi.maxDate)
-                    + ']',
-                "q.geo": '[' + bounds.minX + ',' + bounds.minY + ' TO '
-                            + bounds.maxX + ',' + bounds.maxY + ']'
+            var searchObj = {
+                minDate: new Date('2000-01-01'),
+                maxDate: new Date('2016-12-31'),
+                searchText : ''
             };
 
-            return params;
-        }
-
-        /**
-         * Determines whether passed longitude is outside of the range `-180`
-         * and `+180`.
-         *
-         * @param {number} lon The longitude to check.
-         * @return {boolean} Whether the longitude is outside of the range
-         *  -180` and `+180`.
-         */
-        function outsideLonRange(lon) {
-            return lon < -180 || lon > 180;
-        }
-
-        /**
-         * Determines whether passed latitude is outside of the range `-90` and
-         * `+90`.
-         * @param {number} lat The longitude to check.
-         * @return {boolean} Whether the latitude is outside of the range `-90`
-         *  and `+90`.
-         */
-        function outsideLatRange(lat) {
-            return lat < -90 || lat > 90;
-        }
-
-        /**
-         * Clamps given longitude to be inside the allowed range from `-180` to
-         * `+180`.
-         * @param {number} lon The longitude to fit / clamp.
-         * @return {number} The fitted / clamped longitude.
-         */
-        function clampLon(lon) {
-            return clamp(lon, -180, 180);
-        }
-
-        /**
-         * Clamps given latitude to be inside the allowed range from `-90` to
-         * `+90`.
-         * @param {number} lat The latitude to fit / clamp.
-         * @return {number} The fitted / clamped latitude.
-         */
-        function clampLat(lat) {
-            return clamp(lat, -90, 90);
-        }
-
-        /**
-         * Clamps given number `num` to be inside the allowed range from `min`
-         * to `max`.
-         * Will also work as expected if `max` and `min` are accidently swapped.
-         *
-         * @param {number} num The number to clamp.
-         * @param {number} min The minimum allowed number.
-         * @param {number} max The maximim allowed number.
-         * @return {number} The clamped number.
-         */
-        function clamp(num, min, max) {
-            if (max < min) {
-                var tmp = min;
-                min = max;
-                max = tmp;
-            }
-            return Math.min(Math.max(min, num), max);
-        }
-
-        /**
-         * Normalizes an `EPSG:4326` extent which may stem from multiple worlds
-         * so that the returned extent always is within the bounds of the one
-         * true `EPSG:4326` world extent `[-180, -90, 180, 90]`.
-         *
-         * Examples:
-         *
-         *     // valid world in, returned as-is:
-         *     normalize([-180, -90, 180, 90])  // => [-180, -90, 180, 90]
-         *
-         *     // valid extent in world in, returned as-is:
-         *     normalize([-160, -70, 150, 70])  // => [-160, -70, 150, 70]
-         *
-         *     // shifted one degree westwards, returns one-true world:
-         *     normalize([-181, -90, 179, 90])  // => [-180, -90, 180, 90]
-         *
-         *     // shifted one degree eastwards, returns one-true world:
-         *     normalize([-179, -90, 181, 90])  // => [-180, -90, 180, 90]);
-         *
-         *     // shifted more than one world westwards, returns one-true world:
-         *     normalize([-720, -90, -360, 90]) // => [-180, -90, 180, 90]);
-         *
-         *     // shifted to the south, returns one-true world:
-         *     normalize([-180, -91, 180, 89])  // =>   [-180, -90, 180, 90]);
-         *
-         *     // multiple worlds, returns one-true world:
-         *     normalize([-360, -90, 180, 90])  // =>   [-180, -90, 180, 90]);
-         *
-         *     // multiple worlds, returns one-true world:
-         *     normalize([-360, -180, 180, 90]) // =>  [-180, -90, 180, 90]);
-         *
-         * @param {Array<number>} Extent to normalize: [minx, miny, maxx, maxy].
-         * @return {Array<number>} Normalized extent: [minx, miny, maxx, maxy].
-         */
-        function normalize(extent) {
-            var minX = extent[0];
-            var minY = extent[1];
-            var maxX = extent[2];
-            var maxY = extent[3];
-            var width = Math.min(maxX - minX, 360);
-            var height = Math.min(maxY - minY, 180);
-
-            if (outsideLonRange(minX)) {
-                minX = clampLon(minX);
-                maxX = minX + width;
-            } else if (outsideLonRange(maxX)) {
-                maxX = clampLon(maxX);
-                minX = maxX - width;
+            /**
+             * Set keyword text
+             */
+            function setSearchText(val) {
+                searchObj.searchText = val;
             }
 
-            if (outsideLatRange(minY)) {
-                minY = clampLat(minY);
-                maxY = minY + height;
-            } else if (outsideLatRange(maxY)) {
-                maxY = clampLat(maxY);
-                minY = maxY - height;
+            /**
+             * Set start search date
+             */
+            function setMinDate(val) {
+                searchObj.minDate = val;
             }
 
-            return [minX, minY, maxX, maxY];
-        }
+            /**
+             * Set end search date
+             */
+            function setMaxDate (val) {
+                searchObj.maxDate = val;
+            }
 
-        /**
-         * Returns the formatted date object that can be parsed by API.
-         * @param {Date} date full date object
-                        (e.g. 'Sat Jan 01 2000 01:00:00 GMT+0100 (CET))
-         * @return {String} formatted date as string (e.g. '2000-01-01')
-         */
-        function getFormattedDateString(date){
-            return date.getFullYear() + "-" + ("0" +
-                (date.getMonth() + 1)).slice(-2) + "-" + ("0" + date.getDate()).
-                slice(-2);
-        }
-    }]);
+            /**
+             * Returns the complete search object
+             */
+            function getSearchObj(){
+                return searchObj;
+            }
+
+            /**
+             * Builds geospatial filter depending on the current map extent.
+             * This filter will be used later for `q.geo` parameter of the API
+             * search or export request.
+             */
+            function getGeospatialFilter(){
+                var map = MapService.getMap(),
+                    viewProj = map.getView().getProjection().getCode(),
+                    extent = map.getView().calculateExtent(map.getSize()),
+                    extentWgs84 = ol.proj.
+                                    transformExtent(extent, viewProj, 'EPSG:4326'),
+                    geoFilter = {};
+
+                if (extent && extentWgs84){
+                    var normalizedExtent = normalize(extentWgs84);
+
+                    var minX = normalizedExtent[1],
+                        maxX = normalizedExtent[3],
+                        minY = normalizedExtent[0],
+                        maxY = normalizedExtent[2];
+
+                    geoFilter = {
+                        minX: minX,
+                        maxX: maxX,
+                        minY: minY,
+                        maxY: maxY
+                    };
+                }
+
+                return geoFilter;
+            }
+
+            /**
+             * Performs search with the given full configuration / search object.
+             */
+            function performSearch(){
+                var config = {},
+                    params = this.getTweetsSearchQueryParameters(
+                                                    this.getGeospatialFilter());
+
+                // add additional parameter for the soft maximum of the heatmap grid
+                params["a.hm.limit"] = solrHeatmapApp.bopwsConfig.heatmapFacetLimit;
+
+                if (params) {
+
+                    config = {
+                        url: solrHeatmapApp.appConfig.tweetsSearchBaseUrl,
+                        method: 'GET',
+                        params: params
+                    };
+
+                  //load the data
+                    $http(config).
+                    success(function(data, status, headers, cfg) {
+                        // check if we have a heatmap facet and update the map
+                        if (data && data["a.hm"]) {
+                            MapService.createOrUpdateHeatMapLayer(data["a.hm"]);
+                            // get the count of matches
+                            $rootScope.$broadcast('setCounter',data["a.matchDocs"]);
+                        }
+                    }).
+                    error(function(data, status, headers, cfg) {
+                        // hide the loading mask
+                        $window.alert("An error occured while reading heatmap");
+                    });
+                }
+            }
+
+            /**
+             * Help method to build the whole params object, that will be used in
+             * the API requests.
+             */
+            function startCsvExport(){
+                var config = {},
+                    params = this.getTweetsSearchQueryParameters(
+                                            this.getGeospatialFilter());
+                    // add additional parameter for number of documents to return
+                params["d.docs.limit"] =
+                                solrHeatmapApp.bopwsConfig.csvDocsLimit;
+
+                if (params) {
+                    config = {
+                        url: solrHeatmapApp.appConfig.tweetsExportBaseUrl,
+                        method: 'GET',
+                        params: params
+                    };
+
+                    //start the export
+                    $http(config).
+                    success(function(data, status, headers, cfg) {
+                        var anchor = angular.element('<a/>');
+                        anchor.css({display: 'none'}); // Make sure it's not visible
+                        angular.element($document.body).append(anchor);
+                         // Attach to document
+                        anchor.attr({
+                            href: 'data:attachment/csv;charset=utf-8,' +
+                                                                encodeURI(data),
+                            target: '_blank',
+                            download: 'bop_export.csv'
+                        })[0].click();
+                        anchor.remove(); // Clean it up afterwards
+                    }).
+                    error(function(data, status, headers, cfg) {
+                        $window.alert("An error occured while exporting csv data");
+                    });
+                }
+            }
+
+            /**
+             *
+             */
+            function getTweetsSearchQueryParameters(bounds) {
+
+                // get keyword and time range
+                var reqParamsUi = this.getSearchObj(),
+                    keyword;
+
+                if (reqParamsUi.searchText.length === 0){
+                    keyword = '*';
+                } else {
+                    keyword = reqParamsUi.searchText;
+                }
+
+                var params = {
+                    "q.text": keyword,
+                    "q.time": '['+this.getFormattedDateString(reqParamsUi.minDate) +
+                         ' TO ' + this.getFormattedDateString(reqParamsUi.maxDate) +
+                         ']',
+                    "q.geo": '[' + bounds.minX + ',' + bounds.minY + ' TO ' +
+                                 bounds.maxX + ',' + bounds.maxY + ']'
+                };
+
+                return params;
+            }
+
+            /**
+             * Clamps given number `num` to be inside the allowed range from `min`
+             * to `max`.
+             * Will also work as expected if `max` and `min` are accidently swapped.
+             *
+             * @param {number} num The number to clamp.
+             * @param {number} min The minimum allowed number.
+             * @param {number} max The maximim allowed number.
+             * @return {number} The clamped number.
+             */
+            function clamp(num, min, max) {
+                if (max < min) {
+                    var tmp = min;
+                    min = max;
+                    max = tmp;
+                }
+                return Math.min(Math.max(min, num), max);
+            }
+
+            /**
+             * Determines whether passed longitude is outside of the range `-180`
+             * and `+180`.
+             *
+             * @param {number} lon The longitude to check.
+             * @return {boolean} Whether the longitude is outside of the range
+             *  -180` and `+180`.
+             */
+            function outsideLonRange(lon) {
+                return lon < -180 || lon > 180;
+            }
+
+            /**
+             * Determines whether passed latitude is outside of the range `-90` and
+             * `+90`.
+             * @param {number} lat The longitude to check.
+             * @return {boolean} Whether the latitude is outside of the range `-90`
+             *  and `+90`.
+             */
+            function outsideLatRange(lat) {
+                return lat < -90 || lat > 90;
+            }
+
+            /**
+             * Clamps given longitude to be inside the allowed range from `-180` to
+             * `+180`.
+             * @param {number} lon The longitude to fit / clamp.
+             * @return {number} The fitted / clamped longitude.
+             */
+            function clampLon(lon) {
+                return clamp(lon, -180, 180);
+            }
+
+            /**
+             * Clamps given latitude to be inside the allowed range from `-90` to
+             * `+90`.
+             * @param {number} lat The latitude to fit / clamp.
+             * @return {number} The fitted / clamped latitude.
+             */
+            function clampLat(lat) {
+                return clamp(lat, -90, 90);
+            }
+
+            /**
+             * Normalizes an `EPSG:4326` extent which may stem from multiple worlds
+             * so that the returned extent always is within the bounds of the one
+             * true `EPSG:4326` world extent `[-180, -90, 180, 90]`.
+             *
+             * Examples:
+             *
+             *     // valid world in, returned as-is:
+             *     normalize([-180, -90, 180, 90])  // => [-180, -90, 180, 90]
+             *
+             *     // valid extent in world in, returned as-is:
+             *     normalize([-160, -70, 150, 70])  // => [-160, -70, 150, 70]
+             *
+             *     // shifted one degree westwards, returns one-true world:
+             *     normalize([-181, -90, 179, 90])  // => [-180, -90, 180, 90]
+             *
+             *     // shifted one degree eastwards, returns one-true world:
+             *     normalize([-179, -90, 181, 90])  // => [-180, -90, 180, 90]);
+             *
+             *     // shifted more than one world westwards, returns one-true world:
+             *     normalize([-720, -90, -360, 90]) // => [-180, -90, 180, 90]);
+             *
+             *     // shifted to the south, returns one-true world:
+             *     normalize([-180, -91, 180, 89])  // =>   [-180, -90, 180, 90]);
+             *
+             *     // multiple worlds, returns one-true world:
+             *     normalize([-360, -90, 180, 90])  // =>   [-180, -90, 180, 90]);
+             *
+             *     // multiple worlds, returns one-true world:
+             *     normalize([-360, -180, 180, 90]) // =>  [-180, -90, 180, 90]);
+             *
+             * @param {Array<number>} Extent to normalize: [minx, miny, maxx, maxy].
+             * @return {Array<number>} Normalized extent: [minx, miny, maxx, maxy].
+             */
+            function normalize(extent) {
+                var minX = extent[0];
+                var minY = extent[1];
+                var maxX = extent[2];
+                var maxY = extent[3];
+                var width = Math.min(maxX - minX, 360);
+                var height = Math.min(maxY - minY, 180);
+
+                if (outsideLonRange(minX)) {
+                    minX = clampLon(minX);
+                    maxX = minX + width;
+                } else if (outsideLonRange(maxX)) {
+                    maxX = clampLon(maxX);
+                    minX = maxX - width;
+                }
+
+                if (outsideLatRange(minY)) {
+                    minY = clampLat(minY);
+                    maxY = minY + height;
+                } else if (outsideLatRange(maxY)) {
+                    maxY = clampLat(maxY);
+                    minY = maxY - height;
+                }
+
+                return [minX, minY, maxX, maxY];
+            }
+
+            /**
+             * Returns the formatted date object that can be parsed by API.
+             * @param {Date} date full date object
+                            (e.g. 'Sat Jan 01 2000 01:00:00 GMT+0100 (CET))
+             * @return {String} formatted date as string (e.g. '2000-01-01')
+             */
+            function getFormattedDateString(date){
+                return date.getFullYear() + "-" + ("0" +
+                    (date.getMonth() + 1)).slice(-2) + "-" + ("0" + date.getDate()).
+                    slice(-2);
+            }
+
+            var methods = {
+                getGeospatialFilter: getGeospatialFilter,
+                getTweetsSearchQueryParameters: getTweetsSearchQueryParameters,
+                performSearch: performSearch,
+                startCsvExport: startCsvExport,
+                setSearchText: setSearchText,
+                setMinDate: setMinDate,
+                setMaxDate: setMaxDate,
+                getFormattedDateString: getFormattedDateString,
+                getSearchObj: getSearchObj
+            };
+
+            return methods;
+
+        }]
+);

--- a/app/service/Map.js
+++ b/app/service/Map.js
@@ -1,9 +1,9 @@
+/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.factory.*" }]*/
 /**
  * Map Service
  */
-angular
-    .module('SolrHeatmapApp')
-    .factory('Map', ['$rootScope', '$filter', '$http', function($rootScope, $filter, $http) {
+angular.module('SolrHeatmapApp')
+    .factory('Map', ['$rootScope', '$filter', function($rootScope, $filter) {
 
         var map = {},
             defaults = {
@@ -35,8 +35,10 @@ angular
          *
          */
         function init(config) {
-            var viewConfig = angular.extend(defaults.view, config.mapConfig.view),
-                rendererConfig = angular.extend(defaults.renderer, config.mapConfig.renderer),
+            var viewConfig = angular.extend(defaults.view,
+                                                config.mapConfig.view),
+                rendererConfig = angular.extend(defaults.renderer,
+                                                config.mapConfig.renderer),
                 layerConfig = config.mapConfig.layers;
 
             map = new ol.Map({
@@ -114,7 +116,7 @@ angular
                                 logo: conf.logo,
                                 params: conf.params,
                                 resolutions: conf.resoltions,
-                                url: conf.url,
+                                url: conf.url
                             }),
                             opacity: conf.opacity,
                             visible: conf.visible
@@ -167,9 +169,10 @@ angular
          */
         function displayFeatureInfo(evt) {
             var coord = evt.coordinate,
-                feature = map.forEachFeatureAtPixel(evt.pixel, function(feature, layer) {
-                    return feature;
-                }),
+                feature = map.forEachFeatureAtPixel(evt.pixel,
+                        function(feat, layer) {
+                            return feat;
+                        }),
                 msg = '',
                 evtCnt = 0,
                 lyrCnt = 0;
@@ -199,20 +202,20 @@ angular
             map.addOverlay(overlay);
 
             if (feature) {
-              var data = feature.get('origVal');
-              if (data) {
-                   $rootScope.$broadcast('featureInfoLoaded', data);
-              }
+                var data = feature.get('origVal');
+                if (data) {
+                    $rootScope.$broadcast('featureInfoLoaded', data);
+                }
             }
 
-            $rootScope.$on('featureInfoLoaded', function(evt, data) {
-               msg += '<h5>Number of elements: </h5>' + data;
-               content.innerHTML = msg;
-               var overlay = solrHeatmapApp.map.getOverlays().getArray()[0];
-               if (overlay) {
-                 overlay.setPosition(coord);
-               }
-           });
+            $rootScope.$on('featureInfoLoaded', function(event, dta) {
+                msg += '<h5>Number of elements: </h5>' + data;
+                content.innerHTML = msg;
+                var overlayFi = solrHeatmapApp.map.getOverlays().getArray()[0];
+                if (overlayFi) {
+                    overlayFi.setPosition(coord);
+                }
+            });
 
         }
 
@@ -232,8 +235,7 @@ angular
             newHeatMapLayer = new ol.layer.Heatmap({
              name: 'HeatMapLayer',
              source: olVecSrc,
-             radius: 10,
-             //opacity: 0.25
+             radius: 10
            });
             map.addLayer(newHeatMapLayer);
           }
@@ -258,96 +260,98 @@ angular
                 sx = dx / gridColumns,
                 sy = dy / gridRows,
                 olFeatures = [],
-                map = this.getMap(),
                 minMaxValue,
-                sumOfAllVals = 0;
+                sumOfAllVals = 0,
+                olVecSrc;
 
             if (!counts_ints2D) {
-              return null;
+                return null;
             }
-            minMaxValue = this.heatmapMinMax(counts_ints2D, gridRows, gridColumns);
+            minMaxValue = this.heatmapMinMax(counts_ints2D,
+                                                    gridRows, gridColumns);
             for (var i = 0 ; i < gridRows ; i++){
-              for (var j = 0 ; j < gridColumns ; j++){
-                  var hmVal = counts_ints2D[counts_ints2D.length - i - 1][j],
-                      lon,
-                      lat,
-                      feat,
-                      coords;
+                for (var j = 0 ; j < gridColumns ; j++){
+                    var hmVal = counts_ints2D[counts_ints2D.length - i - 1][j],
+                        lon,
+                        lat,
+                        feat,
+                        coords;
 
-                  if (hmVal && hmVal !== null){
-                    lat = minY + i*sy + (0.5 * sy);
-                    lon = minX + j*sx + (0.5 * sx);
-                    coords = ol.proj.transform(
-                      [lon, lat],
-                      hmProjection,
-                      map.getView().getProjection().getCode()
-                    );
+                    if (hmVal && hmVal !== null){
+                        lat = minY + i*sy + (0.5 * sy);
+                        lon = minX + j*sx + (0.5 * sx);
+                        coords = ol.proj.transform(
+                          [lon, lat],
+                          hmProjection,
+                          map.getView().getProjection().getCode()
+                        );
 
-                    feat = new ol.Feature({
-                      geometry: new ol.geom.Point(coords)
-                    });
+                        feat = new ol.Feature({
+                            geometry: new ol.geom.Point(coords)
+                        });
 
-                    // needs to be rescaled.
-                    var scaledValue = this.rescaleHeatmapValue(hmVal, minMaxValue);
-                    feat.set('weight',  scaledValue);
-                    feat.set('origVal', hmVal);
+                        // needs to be rescaled.
+                        var scaledValue = this.rescaleHeatmapValue(hmVal,
+                                                                minMaxValue);
+                        feat.set('weight', scaledValue);
+                        feat.set('origVal', hmVal);
 
-                    olFeatures.push(feat);
-                  }
-              }
+                        olFeatures.push(feat);
+                    }
+                }
             }
 
             olVecSrc = new ol.source.Vector({
-              features: olFeatures,
-              useSpatialIndex: true
+                features: olFeatures,
+                useSpatialIndex: true
             });
             return olVecSrc;
 
         }
 
         function heatmapMinMax(heatmap, stepsLatitude, stepsLongitude){
-          var max = -1;
-          var min = Number.MAX_VALUE;
-          for (var i = 0 ; i < stepsLatitude ; i++){
-            var currentRow = heatmap[i];
-            if (currentRow === null){
-              heatmap[i] = currentRow = [];
-            }
-            for (var j = 0 ; j < stepsLongitude ; j++){
-              if (currentRow[j] === null){
-                currentRow[j] = -1;
-              }
+            var max = -1;
+            var min = Number.MAX_VALUE;
+            for (var i = 0 ; i < stepsLatitude ; i++){
+                var currentRow = heatmap[i];
+                if (currentRow === null){
+                    heatmap[i] = currentRow = [];
+                }
+                for (var j = 0 ; j < stepsLongitude ; j++){
+                    if (currentRow[j] === null){
+                        currentRow[j] = -1;
+                    }
 
-              if (currentRow[j] > max){
-                max = currentRow[j];
-              }
+                    if (currentRow[j] > max){
+                        max = currentRow[j];
+                    }
 
-              if (currentRow[j] < min && currentRow[j] > -1){
-                min = currentRow[j];
-              }
+                    if (currentRow[j] < min && currentRow[j] > -1){
+                        min = currentRow[j];
+                    }
+                }
             }
-          }
-          return [min, max];
+            return [min, max];
         }
 
         function rescaleHeatmapValue(value, minMaxValue){
-          if (value === null){
-            return 0;
-          }
+            if (value === null){
+                return 0;
+            }
 
-          if (value == -1){
-            return -1;
-          }
+            if (value === -1){
+                return -1;
+            }
 
-          if (value === 0){
-            return 0;
-          }
+            if (value === 0){
+                return 0;
+            }
 
-          if ((minMaxValue[1] - minMaxValue[0]) === 0){
-            return 0;
-          }
+            if ((minMaxValue[1] - minMaxValue[0]) === 0){
+                return 0;
+            }
 
-          return (value - minMaxValue[0]) / (minMaxValue[1] - minMaxValue[0]) ;
+            return (value - minMaxValue[0]) / (minMaxValue[1] - minMaxValue[0]);
         }
 
     }]);

--- a/app/service/Map.js
+++ b/app/service/Map.js
@@ -1,357 +1,361 @@
-/*eslint max-len: ["error", { "ignorePattern": "^\s{4}.factory.*" }]*/
+/*eslint angular/di: [2,"array"]*/
+/*eslint angular/document-service: 2*/
+/*eslint max-len: [2,90]*/
 /**
  * Map Service
  */
 angular.module('SolrHeatmapApp')
-    .factory('Map', ['$rootScope', '$filter', function($rootScope, $filter) {
+    .factory('Map', ['$rootScope', '$filter', '$document',
+        function($rootScope, $filter, $document) {
 
-        var map = {},
-            defaults = {
-                renderer: 'canvas',
-                view: {
-                    center: [0 ,0],
-                    projection: 'EPSG:3857',
-                    zoom: 2
-                }
-            };
-
-        var ms = {
-            //map: map,
-            init: init,
-            getMap: getMap,
-            getLayersBy: getLayersBy,
-            getInteractionsByClass: getInteractionsByClass,
-            getInteractionsByType: getInteractionsByType,
-            displayFeatureInfo: displayFeatureInfo,
-            createOrUpdateHeatMapLayer: createOrUpdateHeatMapLayer,
-            createHeatMapSource: createHeatMapSource,
-            heatmapMinMax: heatmapMinMax,
-            rescaleHeatmapValue: rescaleHeatmapValue
-        };
-
-        return ms;
-
-        /**
-         *
-         */
-        function init(config) {
-            var viewConfig = angular.extend(defaults.view,
-                                                config.mapConfig.view),
-                rendererConfig = angular.extend(defaults.renderer,
-                                                config.mapConfig.renderer),
-                layerConfig = config.mapConfig.layers;
-
-            map = new ol.Map({
-                controls: ol.control.defaults().extend([
-                    new ol.control.ScaleLine(),
-                    new ol.control.ZoomSlider()
-                ]),
-                interactions: ol.interaction.defaults(),
-                layers: buildMapLayers(layerConfig),
-                renderer: angular.isString(rendererConfig) ? rendererConfig :
-                    undefined,
-                target: 'map',
-                view: new ol.View({
-                    center: angular.isArray(viewConfig.center) ?
-                            viewConfig.center : undefined,
-                    maxZoom: angular.isNumber(viewConfig.maxZoom) ?
-                            viewConfig.maxZoom : undefined,
-                    minZoom: angular.isNumber(viewConfig.minZoom) ?
-                            viewConfig.minZoom : undefined,
-                    projection: angular.isString(viewConfig.projection) ?
-                            viewConfig.projection : undefined,
-                    resolution: angular.isString(viewConfig.resolution) ?
-                            viewConfig.resolution : undefined,
-                    resolutions: angular.isArray(viewConfig.resolutions) ?
-                            viewConfig.resolutions : undefined,
-                    rotation: angular.isNumber(viewConfig.rotation) ?
-                            viewConfig.rotation : undefined,
-                    zoom: angular.isNumber(viewConfig.zoom) ?
-                            viewConfig.zoom : undefined,
-                    zoomFactor: angular.isNumber(viewConfig.zoomFactor) ?
-                            viewConfig.zoomFactor : undefined
-                })
-            });
-        }
-
-        /**
-         *
-         */
-        function buildMapLayers(layerConfig) {
-            var layer,
-                layers = [];
-
-            if (angular.isArray(layerConfig)) {
-                angular.forEach(layerConfig, function(conf) {
-                    if (conf.type === 'TileWMS') {
-                        layer = new ol.layer.Tile({
-                            name: conf.name,
-                            backgroundLayer: conf.backgroundLayer,
-                            displayInLayerPanel: conf.displayInLayerPanel,
-                            source: new ol.source.TileWMS({
-                                attributions: [new ol.Attribution({
-                                    html: conf.attribution
-                                })],
-                                crossOrigin: conf.crossOrigin,
-                                logo: conf.logo,
-                                params: conf.params,
-                                ratio: conf.ratio,
-                                resolutions: conf.resoltions,
-                                url: conf.url
-                            }),
-                            opacity: conf.opacity,
-                            visible: conf.visible
-                        });
+            var map = {},
+                defaults = {
+                    renderer: 'canvas',
+                    view: {
+                        center: [0 ,0],
+                        projection: 'EPSG:3857',
+                        zoom: 2
                     }
-                    if (conf.type === 'ImageWMS') {
-                        layer = new ol.layer.Image({
-                            name: conf.name,
-                            backgroundLayer: conf.backgroundLayer,
-                            displayInLayerPanel: conf.displayInLayerPanel,
-                            source: new ol.source.ImageWMS({
-                                attributions: [new ol.Attribution({
-                                    html: conf.attribution
-                                })],
-                                crossOrigin: conf.crossOrigin,
-                                logo: conf.logo,
-                                params: conf.params,
-                                resolutions: conf.resoltions,
-                                url: conf.url
-                            }),
-                            opacity: conf.opacity,
-                            visible: conf.visible
-                        });
-                    }
-                    layers.push(layer);
+                },
+                rs = $rootScope;
+
+            /**
+             *
+             */
+            function init(config) {
+                var viewConfig = angular.extend(defaults.view,
+                                                    config.mapConfig.view),
+                    rendererConfig = angular.extend(defaults.renderer,
+                                                    config.mapConfig.renderer),
+                    layerConfig = config.mapConfig.layers;
+
+                map = new ol.Map({
+                    controls: ol.control.defaults().extend([
+                        new ol.control.ScaleLine(),
+                        new ol.control.ZoomSlider()
+                    ]),
+                    interactions: ol.interaction.defaults(),
+                    layers: buildMapLayers(layerConfig),
+                    renderer: angular.isString(rendererConfig) ?
+                                            rendererConfig : undefined,
+                    target: 'map',
+                    view: new ol.View({
+                        center: angular.isArray(viewConfig.center) ?
+                                viewConfig.center : undefined,
+                        maxZoom: angular.isNumber(viewConfig.maxZoom) ?
+                                viewConfig.maxZoom : undefined,
+                        minZoom: angular.isNumber(viewConfig.minZoom) ?
+                                viewConfig.minZoom : undefined,
+                        projection: angular.isString(viewConfig.projection) ?
+                                viewConfig.projection : undefined,
+                        resolution: angular.isString(viewConfig.resolution) ?
+                                viewConfig.resolution : undefined,
+                        resolutions: angular.isArray(viewConfig.resolutions) ?
+                                viewConfig.resolutions : undefined,
+                        rotation: angular.isNumber(viewConfig.rotation) ?
+                                viewConfig.rotation : undefined,
+                        zoom: angular.isNumber(viewConfig.zoom) ?
+                                viewConfig.zoom : undefined,
+                        zoomFactor: angular.isNumber(viewConfig.zoomFactor) ?
+                                viewConfig.zoomFactor : undefined
+                    })
                 });
             }
-            return layers;
-        }
 
-        /**
-         *
-         */
-        function getLayersBy(key, value) {
-            var layers = this.getMap().getLayers().getArray();
-            return $filter('filter')(layers, function(layer) {
-                return layer.get(key) === value;
-            });
-        }
+            /**
+             *
+             */
+            function buildMapLayers(layerConfig) {
+                var layer,
+                    layers = [];
 
-        /**
-         *
-         */
-        function getInteractionsByClass(value) {
-            var interactions = solrHeatmapApp.map.getInteractions().getArray();
-            return $filter('filter')(interactions, function(interaction) {
-                return interaction instanceof value;
-            });
-        }
+                if (angular.isArray(layerConfig)) {
+                    angular.forEach(layerConfig, function(conf) {
+                        if (conf.type === 'TileWMS') {
+                            layer = new ol.layer.Tile({
+                                name: conf.name,
+                                backgroundLayer: conf.backgroundLayer,
+                                displayInLayerPanel: conf.displayInLayerPanel,
+                                source: new ol.source.TileWMS({
+                                    attributions: [new ol.Attribution({
+                                        html: conf.attribution
+                                    })],
+                                    crossOrigin: conf.crossOrigin,
+                                    logo: conf.logo,
+                                    params: conf.params,
+                                    ratio: conf.ratio,
+                                    resolutions: conf.resoltions,
+                                    url: conf.url
+                                }),
+                                opacity: conf.opacity,
+                                visible: conf.visible
+                            });
+                        }
+                        if (conf.type === 'ImageWMS') {
+                            layer = new ol.layer.Image({
+                                name: conf.name,
+                                backgroundLayer: conf.backgroundLayer,
+                                displayInLayerPanel: conf.displayInLayerPanel,
+                                source: new ol.source.ImageWMS({
+                                    attributions: [new ol.Attribution({
+                                        html: conf.attribution
+                                    })],
+                                    crossOrigin: conf.crossOrigin,
+                                    logo: conf.logo,
+                                    params: conf.params,
+                                    resolutions: conf.resoltions,
+                                    url: conf.url
+                                }),
+                                opacity: conf.opacity,
+                                visible: conf.visible
+                            });
+                        }
+                        layers.push(layer);
+                    });
+                }
+                return layers;
+            }
 
-        /**
-         *
-         */
-        function getInteractionsByType(interactions, type) {
-            return $filter('filter')(interactions, function(interaction) {
-                return interaction.type_ === type;
-            });
-        }
+            /**
+             *
+             */
+            function getLayersBy(key, value) {
+                var layers = this.getMap().getLayers().getArray();
+                return $filter('filter')(layers, function(layer) {
+                    return layer.get(key) === value;
+                });
+            }
 
-        /**
-         *
-         */
-        function getMap() {
-            return map;
-        }
+            /**
+             *
+             */
+            function getInteractionsByClass(value) {
+                var interactions = solrHeatmapApp.map.
+                                    getInteractions().getArray();
+                return $filter('filter')(interactions, function(interaction) {
+                    return interaction instanceof value;
+                });
+            }
 
-        /**
-         *
-         */
-        function displayFeatureInfo(evt) {
-            var coord = evt.coordinate,
-                feature = map.forEachFeatureAtPixel(evt.pixel,
-                        function(feat, layer) {
-                            return feat;
-                        }),
-                msg = '',
-                evtCnt = 0,
-                lyrCnt = 0;
+            /**
+             *
+             */
+            function getInteractionsByType(interactions, type) {
+                return $filter('filter')(interactions, function(interaction) {
+                    return interaction.type_ === type;
+                });
+            }
 
-            // the popup element
-            var container = document.getElementById('popup');
-            var content = document.getElementById('popup-content');
-            var closer = document.getElementById('popup-closer');
+            /**
+             *
+             */
+            function getMap() {
+                return map;
+            }
 
-            closer.onclick = function() {
-                overlay.setPosition(undefined);
-                closer.blur();
-                return false;
+            /**
+             *
+             */
+            function displayFeatureInfo(evt) {
+                var coord = evt.coordinate,
+                    feature = map.forEachFeatureAtPixel(evt.pixel,
+                            function(feat, layer) {
+                                return feat;
+                            }),
+                    msg = '',
+                    evtCnt = 0,
+                    lyrCnt = 0,
+                    container = $document[0].getElementById('popup'),
+                    content = $document[0].getElementById('popup-content'),
+                    closer = $document[0].getElementById('popup-closer'),
+                    overlay = new ol.Overlay({
+                        element: container,
+                        autoPan: true,
+                        autoPanAnimation: {
+                            duration: 250
+                        }
+                    });
+
+                closer.onclick = function() {
+                    overlay.setPosition(undefined);
+                    closer.blur();
+                    return false;
+                };
+
+                // remove any existing overlay before adding a new one
+                map.getOverlays().clear();
+                map.addOverlay(overlay);
+
+                if (feature) {
+                    var data = feature.get('origVal');
+                    if (data) {
+                        $rootScope.$broadcast('featureInfoLoaded', data);
+                    }
+                }
+
+                rs.$on('featureInfoLoaded', function(event, dta) {
+                    msg += '<h5>Number of elements: </h5>' + data;
+                    content.innerHTML = msg;
+                    var overlayFi = solrHeatmapApp.
+                                map.getOverlays().getArray()[0];
+                    if (overlayFi) {
+                        overlayFi.setPosition(coord);
+                    }
+                });
+
+            }
+
+            function createOrUpdateHeatMapLayer(data) {
+                var olVecSrc = this.createHeatMapSource(data),
+                    existingHeatMapLayers = this.getLayersBy('name', 'HeatMapLayer'),
+                    newHeatMapLayer;
+                if (existingHeatMapLayers && existingHeatMapLayers.length > 0){
+                    var currHeatmapLayer = existingHeatMapLayers[0];
+                    // Update layer source
+                    var layerSrc = currHeatmapLayer.getSource();
+                    if (layerSrc){
+                        layerSrc.clear();
+                    }
+                    currHeatmapLayer.setSource(olVecSrc);
+                } else {
+                    newHeatMapLayer = new ol.layer.Heatmap({
+                        name: 'HeatMapLayer',
+                        source: olVecSrc,
+                        radius: 10
+                    });
+                    map.addLayer(newHeatMapLayer);
+                }
+            }
+
+            /*
+             *
+             */
+            function createHeatMapSource(hmParams) {
+                var counts_ints2D = hmParams.counts_ints2D,
+                    gridLevel = hmParams.gridLevel,
+                    gridColumns = hmParams.columns,
+                    gridRows = hmParams.rows,
+                    minX = hmParams.minX,
+                    minY = hmParams.minY,
+                    maxX = hmParams.maxX,
+                    maxY = hmParams.maxY,
+                    hmProjection = hmParams.projection,
+                    dx = maxX - minX,
+                    dy = maxY - minY,
+                    sx = dx / gridColumns,
+                    sy = dy / gridRows,
+                    olFeatures = [],
+                    minMaxValue,
+                    sumOfAllVals = 0,
+                    olVecSrc;
+
+                if (!counts_ints2D) {
+                    return null;
+                }
+                minMaxValue = this.heatmapMinMax(counts_ints2D,
+                                                        gridRows, gridColumns);
+                for (var i = 0 ; i < gridRows ; i++){
+                    for (var j = 0 ; j < gridColumns ; j++){
+                        var hmVal = counts_ints2D[counts_ints2D.length-i-1][j],
+                            lon,
+                            lat,
+                            feat,
+                            coords;
+
+                        if (hmVal && hmVal !== null){
+                            lat = minY + i*sy + (0.5 * sy);
+                            lon = minX + j*sx + (0.5 * sx);
+                            coords = ol.proj.transform(
+                              [lon, lat],
+                              hmProjection,
+                              map.getView().getProjection().getCode()
+                            );
+
+                            feat = new ol.Feature({
+                                geometry: new ol.geom.Point(coords)
+                            });
+
+                            // needs to be rescaled.
+                            var scaledValue = this.rescaleHeatmapValue(hmVal,
+                                                                minMaxValue);
+                            feat.set('weight', scaledValue);
+                            feat.set('origVal', hmVal);
+
+                            olFeatures.push(feat);
+                        }
+                    }
+                }
+
+                olVecSrc = new ol.source.Vector({
+                    features: olFeatures,
+                    useSpatialIndex: true
+                });
+                return olVecSrc;
+
+            }
+
+            function heatmapMinMax(heatmap, stepsLatitude, stepsLongitude){
+                var max = -1;
+                var min = Number.MAX_VALUE;
+                for (var i = 0 ; i < stepsLatitude ; i++){
+                    var currentRow = heatmap[i];
+                    if (currentRow === null){
+                        heatmap[i] = currentRow = [];
+                    }
+                    for (var j = 0 ; j < stepsLongitude ; j++){
+                        if (currentRow[j] === null){
+                            currentRow[j] = -1;
+                        }
+
+                        if (currentRow[j] > max){
+                            max = currentRow[j];
+                        }
+
+                        if (currentRow[j] < min && currentRow[j] > -1){
+                            min = currentRow[j];
+                        }
+                    }
+                }
+                return [min, max];
+            }
+
+            function rescaleHeatmapValue(value, minMaxValue){
+                if (value === null){
+                    return 0;
+                }
+
+                if (value === -1){
+                    return -1;
+                }
+
+                if (value === 0){
+                    return 0;
+                }
+
+                if ((minMaxValue[1] - minMaxValue[0]) === 0){
+                    return 0;
+                }
+
+                return (value - minMaxValue[0]) /
+                        (minMaxValue[1] - minMaxValue[0]);
+            }
+
+            var ms = {
+                //map: map,
+                init: init,
+                getMap: getMap,
+                getLayersBy: getLayersBy,
+                getInteractionsByClass: getInteractionsByClass,
+                getInteractionsByType: getInteractionsByType,
+                displayFeatureInfo: displayFeatureInfo,
+                createOrUpdateHeatMapLayer: createOrUpdateHeatMapLayer,
+                createHeatMapSource: createHeatMapSource,
+                heatmapMinMax: heatmapMinMax,
+                rescaleHeatmapValue: rescaleHeatmapValue
             };
 
-            // create an overlay
-            var overlay = new ol.Overlay({
-                element: container,
-                autoPan: true,
-                autoPanAnimation: {
-                  duration: 250
-                }
-            });
+            return ms;
 
-            // remove any existing overlay before adding a new one
-            map.getOverlays().clear();
-            map.addOverlay(overlay);
+        }]
 
-            if (feature) {
-                var data = feature.get('origVal');
-                if (data) {
-                    $rootScope.$broadcast('featureInfoLoaded', data);
-                }
-            }
-
-            $rootScope.$on('featureInfoLoaded', function(event, dta) {
-                msg += '<h5>Number of elements: </h5>' + data;
-                content.innerHTML = msg;
-                var overlayFi = solrHeatmapApp.map.getOverlays().getArray()[0];
-                if (overlayFi) {
-                    overlayFi.setPosition(coord);
-                }
-            });
-
-        }
-
-        function createOrUpdateHeatMapLayer(data) {
-          var olVecSrc = this.createHeatMapSource(data),
-              existingHeatMapLayers = this.getLayersBy('name', 'HeatMapLayer'),
-              newHeatMapLayer;
-          if (existingHeatMapLayers && existingHeatMapLayers.length > 0){
-              var currHeatmapLayer = existingHeatMapLayers[0];
-              // Update layer source
-              var layerSrc = currHeatmapLayer.getSource();
-              if (layerSrc){
-                layerSrc.clear();
-              }
-              currHeatmapLayer.setSource(olVecSrc);
-          } else {
-            newHeatMapLayer = new ol.layer.Heatmap({
-             name: 'HeatMapLayer',
-             source: olVecSrc,
-             radius: 10
-           });
-            map.addLayer(newHeatMapLayer);
-          }
-        }
-
-        /*
-         *
-         */
-        function createHeatMapSource(hmParams) {
-
-            var counts_ints2D = hmParams.counts_ints2D,
-                gridLevel = hmParams.gridLevel,
-                gridColumns = hmParams.columns,
-                gridRows = hmParams.rows,
-                minX = hmParams.minX,
-                minY = hmParams.minY,
-                maxX = hmParams.maxX,
-                maxY = hmParams.maxY,
-                hmProjection = hmParams.projection,
-                dx = maxX - minX,
-                dy = maxY - minY,
-                sx = dx / gridColumns,
-                sy = dy / gridRows,
-                olFeatures = [],
-                minMaxValue,
-                sumOfAllVals = 0,
-                olVecSrc;
-
-            if (!counts_ints2D) {
-                return null;
-            }
-            minMaxValue = this.heatmapMinMax(counts_ints2D,
-                                                    gridRows, gridColumns);
-            for (var i = 0 ; i < gridRows ; i++){
-                for (var j = 0 ; j < gridColumns ; j++){
-                    var hmVal = counts_ints2D[counts_ints2D.length - i - 1][j],
-                        lon,
-                        lat,
-                        feat,
-                        coords;
-
-                    if (hmVal && hmVal !== null){
-                        lat = minY + i*sy + (0.5 * sy);
-                        lon = minX + j*sx + (0.5 * sx);
-                        coords = ol.proj.transform(
-                          [lon, lat],
-                          hmProjection,
-                          map.getView().getProjection().getCode()
-                        );
-
-                        feat = new ol.Feature({
-                            geometry: new ol.geom.Point(coords)
-                        });
-
-                        // needs to be rescaled.
-                        var scaledValue = this.rescaleHeatmapValue(hmVal,
-                                                                minMaxValue);
-                        feat.set('weight', scaledValue);
-                        feat.set('origVal', hmVal);
-
-                        olFeatures.push(feat);
-                    }
-                }
-            }
-
-            olVecSrc = new ol.source.Vector({
-                features: olFeatures,
-                useSpatialIndex: true
-            });
-            return olVecSrc;
-
-        }
-
-        function heatmapMinMax(heatmap, stepsLatitude, stepsLongitude){
-            var max = -1;
-            var min = Number.MAX_VALUE;
-            for (var i = 0 ; i < stepsLatitude ; i++){
-                var currentRow = heatmap[i];
-                if (currentRow === null){
-                    heatmap[i] = currentRow = [];
-                }
-                for (var j = 0 ; j < stepsLongitude ; j++){
-                    if (currentRow[j] === null){
-                        currentRow[j] = -1;
-                    }
-
-                    if (currentRow[j] > max){
-                        max = currentRow[j];
-                    }
-
-                    if (currentRow[j] < min && currentRow[j] > -1){
-                        min = currentRow[j];
-                    }
-                }
-            }
-            return [min, max];
-        }
-
-        function rescaleHeatmapValue(value, minMaxValue){
-            if (value === null){
-                return 0;
-            }
-
-            if (value === -1){
-                return -1;
-            }
-
-            if (value === 0){
-                return 0;
-            }
-
-            if ((minMaxValue[1] - minMaxValue[0]) === 0){
-                return 0;
-            }
-
-            return (value - minMaxValue[0]) / (minMaxValue[1] - minMaxValue[0]);
-        }
-
-    }]);
+);

--- a/app/view/datePicker.html
+++ b/app/view/datePicker.html
@@ -1,4 +1,4 @@
-<div ng-controller="DatePickerCtrl">
+<div ng-controller="DatePickerController">
     <div class="row form-inline" id="fromToDateInputs">
         <div class="col-md-6">
             <label>from:</label>

--- a/app/view/exportButton.html
+++ b/app/view/exportButton.html
@@ -1,4 +1,4 @@
-<div ng-controller="ExportCtrl">
+<div ng-controller="ExportController">
   <button class="btn btn-primary btn-sm pull-right" id="exportbtn" title="EXPORT" type="button" ng-click="startExport()">
     EXPORT
   </button>

--- a/app/view/resultCounterText.html
+++ b/app/view/resultCounterText.html
@@ -1,4 +1,4 @@
-<div ng-controller="ResultCounterCtrl">
+<div ng-controller="ResultCounterController">
   <div id="resultCounterText">
       <form class="form-inline">
           <div class="form-group">

--- a/app/view/toolbarSearchField.html
+++ b/app/view/toolbarSearchField.html
@@ -1,4 +1,4 @@
-<div ng-controller="SearchCtrl">
+<div ng-controller="SearchController">
   <div class="input-group" id="searchinput">
     <input class="form-control input-sm" type="text" placeholder="Enter keyword" ng-keypress="onKeyPress($event)" ng-model="searchInput" ng-click="onFocus()" ng-blur="onBlur()">
     <span class="input-group-btn searchbtn">

--- a/index-dev.html
+++ b/index-dev.html
@@ -35,7 +35,7 @@
 
 </head>
 
-<body ng-controller="mainCtrl">
+<body ng-controller="MainController">
     <div class="container-fluid">
         <div class="row">
             <div class="col-md-12">

--- a/index.html
+++ b/index.html
@@ -26,7 +26,7 @@
     <script src="./build/hm-client.min.js"></script>
 </head>
 
-<body ng-controller="mainCtrl">
+<body ng-controller="MainController">
     <div class="container-fluid">
         <div class="row">
             <div class="col-md-12">

--- a/package.json
+++ b/package.json
@@ -27,12 +27,15 @@
     "Heatmap"
   ],
   "scripts": {
+    "js-lint": "eslint -c .eslintrc ./",
     "deploy": "grunt deploy"
   },
   "dependencies": {},
   "devDependencies": {
     "angular-ui-bootstrap": "^1.3.3",
     "eslint": "^2.13.0",
+    "eslint-config-angular": "^0.5.0",
+    "eslint-plugin-angular": "^1.3.0",
     "grunt": "1.0.1",
     "grunt-cli": "1.2.0",
     "grunt-contrib-clean": "^1.0.0",
@@ -40,6 +43,7 @@
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-uglify": "^1.0.1",
     "grunt-contrib-watch": "^1.0.0",
+    "grunt-eslint": "^19.0.0",
     "grunt-gh-pages": "1.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "grunt-cli": "1.2.0",
     "grunt-contrib-clean": "^1.0.0",
     "grunt-contrib-concat": "^1.0.1",
-    "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-uglify": "^1.0.1",
     "grunt-contrib-watch": "^1.0.0",
     "grunt-gh-pages": "1.1.0"

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "grunt-contrib-jshint": "^1.0.0",
     "grunt-contrib-uglify": "^1.0.1",
     "grunt-contrib-watch": "^1.0.0",
-    "grunt-eslint": "^19.0.0",
     "grunt-gh-pages": "1.1.0"
   }
 }


### PR DESCRIPTION
As announced in terrestris/SolrHeatmap#21 the JavaScript code linting utility was changed to [ESLint](http://eslint.org/).

Beside the `.eslintrc` and the `.eslintignore` based on those of [BasiGX](https://github.com/terrestris/BasiGX), dedicated ESLint rules for angular projects have are introduced using the [ESLint pluginfor AngularJS projects](https://www.npmjs.com/package/eslint-plugin-angular)

Please review @terrestris/owners
