### PR TITLE
Fix Grunt uglify task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,7 +43,8 @@ module.exports = function(grunt) {
         uglify: {
             options: {
               // the banner is inserted at the top of the output
-              banner: '/*! Solr-Heatmap-Client created on <%= grunt.template.today("dd-mm-yyyy") %> */\n'
+              banner: '/*! Solr-Heatmap-Client created on <%= grunt.template.today("dd-mm-yyyy") %> */\n',
+              mangle: false
             },
             dist: {
                 files: {

--- a/app/service/HeatMapSourceGenerator.js
+++ b/app/service/HeatMapSourceGenerator.js
@@ -279,14 +279,15 @@ angular
              * Help method to build the whole params object, that will be used in
              * the API requests.
              */
-            function startCsvExport(){
+            function startCsvExport(numberOfDocuments){
                 var config = {},
                     spatialFilters = this.getGeospatialFilter(),
                     params = this.getTweetsSearchQueryParameters(
                                     spatialFilters.queryGeo, spatialFilters.hmFilter);
 
                 // add additional parameter for the number of documents to return
-                params["d.docs.limit"] = solrHeatmapApp.bopwsConfig.csvDocsLimit;
+                params["d.docs.limit"] = angular.isNumber(numberOfDocuments) ?
+                        numberOfDocuments : solrHeatmapApp.bopwsConfig.csvDocsLimit;
 
                 if (params && spatialFilters !== null) {
                     config = {


### PR DESCRIPTION
This PR add the `mangle` option to the Grunt-uglify task.
Until now, the Controller names are "uglified" as well which leads to errors then a info button is clicked (`$uibModal` has property `controller` where `InfoWindowController` is referenced by name).

In addition, the number of documents (of slider) is included in export tasks.

Please review @annarieger 
